### PR TITLE
This un-disables (enables) live reloading by webpack

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,6 +15,6 @@
          start working.
         </p>
 
-        <script nomodule src="build.js"></script>
+        <script src="build.js"></script>
     </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <link rel="stylesheet" href="css/style.css">
-        <script type="module" src="js/app.js"></script>
     </head>
     <body>
         <h1>Hello World!</h1>


### PR DESCRIPTION
Removing the "nomodule" property from the script tag seems to re-enable live reloading for webpack, since now it (seems) to not be working by default